### PR TITLE
feat: changed report sellers endpoint

### DIFF
--- a/docs/db/melifresh_db.sql
+++ b/docs/db/melifresh_db.sql
@@ -11,7 +11,7 @@ USE
 -- table `localities`
 CREATE TABLE `localities`
 (
-    `id` int(11) NOT NULL,
+    `id` int(11) NOT NULL AUTO_INCREMENT,
     `name` varchar(255) NOT NULL,
     `province_name` varchar(255) NOT NULL,
     `country_name` varchar(255) NOT NULL,

--- a/docs/db/melifresh_db.sql
+++ b/docs/db/melifresh_db.sql
@@ -11,7 +11,7 @@ USE
 -- table `localities`
 CREATE TABLE `localities`
 (
-    `id` int(11) NOT NULL AUTO_INCREMENT,
+    `id` int(11) NOT NULL,
     `name` varchar(255) NOT NULL,
     `province_name` varchar(255) NOT NULL,
     `country_name` varchar(255) NOT NULL,
@@ -98,17 +98,17 @@ CREATE TABLE `buyers`
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8;
 
 -- DML
-INSERT INTO localities (name, province_name, country_name)
-VALUES ('New York City', 'New York', 'United States'),
-       ('Los Angeles', 'California', 'United States'),
-       ('Chicago', 'Illinois', 'United States'),
-       ('Houston', 'Texas', 'United States'),
-       ('Phoenix', 'Arizona', 'United States'),
-       ('Philadelphia', 'Pennsylvania', 'United States'),
-       ('San Antonio', 'Texas', 'United States'),
-       ('San Diego', 'California', 'United States'),
-       ('Dallas', 'Texas', 'United States'),
-       ('San Jose', 'California', 'United States');
+INSERT INTO localities (id, name, province_name, country_name)
+VALUES (1, 'New York City', 'New York', 'United States'),
+       (2 ,'Los Angeles', 'California', 'United States'),
+       (3,'Chicago', 'Illinois', 'United States'),
+       (4, 'Houston', 'Texas', 'United States'),
+       (5, 'Phoenix', 'Arizona', 'United States'),
+       (6, 'Philadelphia', 'Pennsylvania', 'United States'),
+       (7, 'San Antonio', 'Texas', 'United States'),
+       (8, 'San Diego', 'California', 'United States'),
+       (9, 'Dallas', 'Texas', 'United States'),
+       (10, 'San Jose', 'California', 'United States');
 
 INSERT INTO sellers (cid, company_name, address, telephone, locality_id)
 VALUES (1, 'Company A', '123 Main St', '123-456-7890', 1),

--- a/internal/handler/locality.go
+++ b/internal/handler/locality.go
@@ -46,7 +46,7 @@ func (h *LocalityDefault) ReportSellers() http.HandlerFunc {
 
 		switch idStr {
 		case "":
-			sellers, err := h.sv.ReportSellers()
+			localities, err := h.sv.ReportSellers()
 			if err != nil {
 				log.Println(err)
 				if errors.Is(err, internal.ErrLocalityNotFound) {
@@ -57,10 +57,19 @@ func (h *LocalityDefault) ReportSellers() http.HandlerFunc {
 				return
 			}
 
+			var localitiesJson []LocalityGetJson
+			for _, locality := range localities {
+				localitiesJson = append(localitiesJson, LocalityGetJson{
+					ID:           locality.ID,
+					LocalityName: locality.LocalityName,
+					ProvinceName: locality.ProvinceName,
+					CountryName:  locality.CountryName,
+					SellersCount: locality.Sellers,
+				})
+			}
+
 			response.JSON(w, http.StatusOK, map[string]any{
-				"data": map[string]any{
-					"sellers_count": sellers,
-				},
+				"data": localitiesJson,
 			})
 		default:
 			id, err := strconv.Atoi(idStr)

--- a/internal/locality.go
+++ b/internal/locality.go
@@ -56,14 +56,14 @@ func (l *Locality) Validate() (causes []Causes) {
 
 type LocalityRepository interface {
 	Save(locality *Locality) (err error)
-	ReportSellers() (sellers int, err error)
+	ReportSellers() (localities []Locality, err error)
 	ReportSellersByID(id int) (locality Locality, err error)
 	FindByID(id int) (locality Locality, err error)
 }
 
 type LocalityService interface {
 	Save(locality *Locality) (err error)
-	ReportSellers() (sellers int, err error)
+	ReportSellers() (localities []Locality, err error)
 	ReportSellersByID(id int) (locality Locality, err error)
 	FindByID(id int) (locality Locality, err error)
 }

--- a/internal/locality.go
+++ b/internal/locality.go
@@ -56,12 +56,14 @@ func (l *Locality) Validate() (causes []Causes) {
 
 type LocalityRepository interface {
 	Save(locality *Locality) (err error)
-	ReportSellers(id int) (locality Locality, err error)
+	ReportSellers() (sellers int, err error)
+	ReportSellersByID(id int) (locality Locality, err error)
 	FindByID(id int) (locality Locality, err error)
 }
 
 type LocalityService interface {
 	Save(locality *Locality) (err error)
-	ReportSellers(id int) (locality Locality, err error)
+	ReportSellers() (sellers int, err error)
+	ReportSellersByID(id int) (locality Locality, err error)
 	FindByID(id int) (locality Locality, err error)
 }

--- a/internal/locality.go
+++ b/internal/locality.go
@@ -57,13 +57,13 @@ func (l *Locality) Validate() (causes []Causes) {
 type LocalityRepository interface {
 	Save(locality *Locality) (err error)
 	ReportSellers() (localities []Locality, err error)
-	ReportSellersByID(id int) (locality Locality, err error)
+	ReportSellersByID(id int) (localities []Locality, err error)
 	FindByID(id int) (locality Locality, err error)
 }
 
 type LocalityService interface {
 	Save(locality *Locality) (err error)
 	ReportSellers() (localities []Locality, err error)
-	ReportSellersByID(id int) (locality Locality, err error)
+	ReportSellersByID(id int) (localities []Locality, err error)
 	FindByID(id int) (locality Locality, err error)
 }

--- a/internal/repository/locality_mysql.go
+++ b/internal/repository/locality_mysql.go
@@ -38,8 +38,20 @@ func (r *LocalityMysql) Save(locality *internal.Locality) (err error) {
 	return
 }
 
-// ReportSellers returns a seller from the database by its id
-func (r *LocalityMysql) ReportSellers(id int) (locality internal.Locality, err error) {
+func (r *LocalityMysql) ReportSellers() (sellers int, err error) {
+	row := r.db.QueryRow("SELECT COUNT(s.id) FROM sellers AS s WHERE s.locality_id IS NOT NULL;")
+	err = row.Scan(&sellers)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			err = internal.ErrLocalityNotFound
+		}
+	}
+
+	return
+}
+
+// ReportSellersByID returns a seller from the database by its id
+func (r *LocalityMysql) ReportSellersByID(id int) (locality internal.Locality, err error) {
 	// execute the query
 	row := r.db.QueryRow("SELECT l.id, l.name, l.province_name, l.country_name, COUNT(s.id) FROM localities AS l LEFT JOIN sellers AS s ON l.id = s.locality_id WHERE l.id = ? GROUP BY l.id", id)
 

--- a/internal/repository/locality_mysql.go
+++ b/internal/repository/locality_mysql.go
@@ -65,10 +65,11 @@ func (r *LocalityMysql) ReportSellers() (localities []internal.Locality, err err
 }
 
 // ReportSellersByID returns a seller from the database by its id
-func (r *LocalityMysql) ReportSellersByID(id int) (locality internal.Locality, err error) {
+func (r *LocalityMysql) ReportSellersByID(id int) (localities []internal.Locality, err error) {
 	// execute the query
 	row := r.db.QueryRow("SELECT l.id, l.name, l.province_name, l.country_name, COUNT(s.id) FROM localities AS l LEFT JOIN sellers AS s ON l.id = s.locality_id WHERE l.id = ? GROUP BY l.id", id)
 
+	var locality internal.Locality
 	// scan the row into the seller
 	err = row.Scan(&locality.ID, &locality.LocalityName, &locality.ProvinceName, &locality.CountryName, &locality.Sellers)
 	if err != nil {
@@ -76,6 +77,9 @@ func (r *LocalityMysql) ReportSellersByID(id int) (locality internal.Locality, e
 			err = internal.ErrLocalityNotFound
 		}
 	}
+
+	localities = append(localities, locality)
+
 	return
 }
 

--- a/internal/service/locality.go
+++ b/internal/service/locality.go
@@ -30,7 +30,7 @@ func (l *LocalityDefault) Save(locality *internal.Locality) (err error) {
 func (l *LocalityDefault) ReportSellers() (localities []internal.Locality, err error) {
 	return l.rp.ReportSellers()
 }
-func (l *LocalityDefault) ReportSellersByID(id int) (locality internal.Locality, err error) {
+func (l *LocalityDefault) ReportSellersByID(id int) (localities []internal.Locality, err error) {
 	return l.rp.ReportSellersByID(id)
 }
 

--- a/internal/service/locality.go
+++ b/internal/service/locality.go
@@ -27,7 +27,7 @@ func (l *LocalityDefault) Save(locality *internal.Locality) (err error) {
 	return l.rp.Save(locality)
 }
 
-func (l *LocalityDefault) ReportSellers() (sellers int, err error) {
+func (l *LocalityDefault) ReportSellers() (localities []internal.Locality, err error) {
 	return l.rp.ReportSellers()
 }
 func (l *LocalityDefault) ReportSellersByID(id int) (locality internal.Locality, err error) {

--- a/internal/service/locality.go
+++ b/internal/service/locality.go
@@ -27,8 +27,11 @@ func (l *LocalityDefault) Save(locality *internal.Locality) (err error) {
 	return l.rp.Save(locality)
 }
 
-func (l *LocalityDefault) ReportSellers(id int) (locality internal.Locality, err error) {
-	return l.rp.ReportSellers(id)
+func (l *LocalityDefault) ReportSellers() (sellers int, err error) {
+	return l.rp.ReportSellers()
+}
+func (l *LocalityDefault) ReportSellersByID(id int) (locality internal.Locality, err error) {
+	return l.rp.ReportSellersByID(id)
 }
 
 func (l *LocalityDefault) FindByID(id int) (locality internal.Locality, err error) {


### PR DESCRIPTION
This PR changes the behavior of the `/api/v1/localities/reportSellers` endpoint to provide more flexibility in retrieving seller data.

**Changes:**

* **Optional `id` parameter:** The `id` query parameter is now optional.
* **Total sellers with locality_id:** If no `id` is provided, the endpoint returns the total number of sellers who have a `locality_id`.
* **Original functionality preserved:** If an `id` is provided, the endpoint functions as before, returning details for the locality with the given ID, including the seller count.

This enhancement allows clients to easily retrieve both aggregate seller data and locality-specific information.

**Example Usage:**

* **Get all localities with yours respective sellers count** `/reportSellers`
* **Get locality details and seller count for locality with ID 5:** `/reportSellers?id=5`