### PR TITLE
Fix ReportPurchaseOrders

### DIFF
--- a/internal/handler/buyer.go
+++ b/internal/handler/buyer.go
@@ -138,10 +138,6 @@ func (h *BuyerHandlerDefault) ReportPurchaseOrders(w http.ResponseWriter, r *htt
 		switch {
 		case errors.Is(err, service.BuyerNotFound):
 			response.JSON(w, http.StatusNotFound, rest_err.NewNotFoundError(err.Error()))
-		case errors.Is(err, service.ErrPurchaseOrdersNotFound):
-			response.JSON(w, http.StatusNotFound, rest_err.NewNotFoundError(err.Error()))
-		case errors.Is(err, service.ErrPurchaseOrdersByBuyerNotFound):
-			response.JSON(w, http.StatusNotFound, rest_err.NewNotFoundError(err.Error()))
 		default:
 			response.JSON(w, http.StatusInternalServerError, rest_err.NewInternalServerError(err.Error()))
 		}

--- a/internal/handler/buyer_mysql_test.go
+++ b/internal/handler/buyer_mysql_test.go
@@ -79,6 +79,13 @@ func (b *BuyerTestSuite) TestReportPurchaseOrders() {
 					"first_name": "Mark",
 					"last_name": "Jones",
 					"purchase_orders_count": 1
+				}, 
+				{
+					"id": 3,
+					"card_number_id": "B1003",
+					"first_name": "Linda",
+					"last_name": "Garcia",
+					"purchase_orders_count": 0
 				}
 			]
 		}`
@@ -111,7 +118,32 @@ func (b *BuyerTestSuite) TestReportPurchaseOrders() {
 		require.JSONEq(t, expectedBody, response.Body.String())
 	})
 
-	b.T().Run("case 3 - error - Purchase order reports by buyer id that doesn't exists", func(t *testing.T) {
+	b.T().Run("case 3 - success - Purchase order reports by buyer id that doesn't have purchase orders", func(t *testing.T) {
+		// given
+		request := httptest.NewRequest(http.MethodGet, api_buyer+"?id=3", nil)
+		response := httptest.NewRecorder()
+
+		// when
+		b.hd.ReportPurchaseOrders(response, request)
+
+		// then
+		expectedCode := http.StatusOK
+		expectedBody := `{
+			"data": [
+				{
+					"id": 3,
+					"card_number_id": "B1003",
+					"first_name": "Linda",
+					"last_name": "Garcia",
+					"purchase_orders_count": 0
+				}
+			]
+		}`
+		require.Equal(t, expectedCode, response.Code)
+		require.JSONEq(t, expectedBody, response.Body.String())
+	})
+
+	b.T().Run("case 4 - error - Purchase order reports by buyer id that doesn't exists", func(t *testing.T) {
 		// given
 		request := httptest.NewRequest(http.MethodGet, api_buyer+"?id=4", nil)
 		response := httptest.NewRecorder()
@@ -131,23 +163,23 @@ func (b *BuyerTestSuite) TestReportPurchaseOrders() {
 		require.JSONEq(t, expectedBody, response.Body.String())
 	})
 
-	b.T().Run("case 4 - error - Purchase order reports that doesn't exists for the given buyer", func(t *testing.T) {
-		// given
-		request := httptest.NewRequest(http.MethodGet, api_buyer+"?id=3", nil)
-		response := httptest.NewRecorder()
+	// b.T().Run("case 4 - error - Purchase order reports that doesn't exists for the given buyer", func(t *testing.T) {
+	// 	// given
+	// 	request := httptest.NewRequest(http.MethodGet, api_buyer+"?id=3", nil)
+	// 	response := httptest.NewRecorder()
 
-		// when
-		b.hd.ReportPurchaseOrders(response, request)
+	// 	// when
+	// 	b.hd.ReportPurchaseOrders(response, request)
 
-		// then
-		expectedCode := http.StatusNotFound
-		expectedBody := `{
-				"message": "purchase orders not found for the given buyer",
-				"error": "not_found",
-				"code": 404,
-				"causes": null
-			}`
-		require.Equal(t, expectedCode, response.Code)
-		require.JSONEq(t, expectedBody, response.Body.String())
-	})
+	// 	// then
+	// 	expectedCode := http.StatusNotFound
+	// 	expectedBody := `{
+	// 			"message": "purchase orders not found for the given buyer",
+	// 			"error": "not_found",
+	// 			"code": 404,
+	// 			"causes": null
+	// 		}`
+	// 	require.Equal(t, expectedCode, response.Code)
+	// 	require.JSONEq(t, expectedBody, response.Body.String())
+	// })
 }

--- a/internal/handler/buyer_mysql_test.go
+++ b/internal/handler/buyer_mysql_test.go
@@ -162,24 +162,4 @@ func (b *BuyerTestSuite) TestReportPurchaseOrders() {
 		require.Equal(t, expectedCode, response.Code)
 		require.JSONEq(t, expectedBody, response.Body.String())
 	})
-
-	// b.T().Run("case 4 - error - Purchase order reports that doesn't exists for the given buyer", func(t *testing.T) {
-	// 	// given
-	// 	request := httptest.NewRequest(http.MethodGet, api_buyer+"?id=3", nil)
-	// 	response := httptest.NewRecorder()
-
-	// 	// when
-	// 	b.hd.ReportPurchaseOrders(response, request)
-
-	// 	// then
-	// 	expectedCode := http.StatusNotFound
-	// 	expectedBody := `{
-	// 			"message": "purchase orders not found for the given buyer",
-	// 			"error": "not_found",
-	// 			"code": 404,
-	// 			"causes": null
-	// 		}`
-	// 	require.Equal(t, expectedCode, response.Code)
-	// 	require.JSONEq(t, expectedBody, response.Body.String())
-	// })
 }

--- a/internal/repository/buyer_mysql.go
+++ b/internal/repository/buyer_mysql.go
@@ -101,7 +101,7 @@ func (r *BuyerMysqlRepository) ReportPurchaseOrders() (purchaseOrders []internal
 			b.id, b.card_number_id, b.first_name, b.last_name, COUNT(po.id) as purchase_orders_count
 		FROM
 			buyers as b
-		INNER JOIN
+		LEFT JOIN
 			purchase_orders as po ON po.buyer_id = b.id
 		GROUP BY
 			b.id;
@@ -137,7 +137,7 @@ func (r *BuyerMysqlRepository) ReportPurchaseOrdersById(id int) (purchaseOrders 
 			b.id, b.card_number_id, b.first_name, b.last_name, COUNT(po.id) as purchase_orders_count
 		FROM
 			buyers as b
-		INNER JOIN
+		LEFT JOIN
 			purchase_orders as po ON po.buyer_id = b.id
 		GROUP BY
 			b.id

--- a/internal/service/buyer.go
+++ b/internal/service/buyer.go
@@ -7,12 +7,10 @@ import (
 )
 
 var (
-	BuyerNotFound                    = errors.New("buyer not found")
-	BuyerAlreadyExists               = errors.New("buyer already exists")
-	CardNumberAlreadyInUse           = errors.New("buyer with given card number already registered")
-	BuyerUnprocessableEntity         = errors.New("couldn't parse buyer")
-	ErrPurchaseOrdersByBuyerNotFound = errors.New("purchase orders not found for the given buyer")
-	ErrPurchaseOrdersNotFound        = errors.New("purchase orders not found for any buyer")
+	BuyerNotFound            = errors.New("buyer not found")
+	BuyerAlreadyExists       = errors.New("buyer already exists")
+	CardNumberAlreadyInUse   = errors.New("buyer with given card number already registered")
+	BuyerUnprocessableEntity = errors.New("couldn't parse buyer")
 )
 
 func cardNumberIdAlreadyInUse(cardNumber string, buyers map[int]internal.Buyer) bool {
@@ -99,10 +97,6 @@ func (s *BuyerServiceDefault) Delete(id int) (err error) {
 // ReportPurchaseOrders returns all purchase orders of all buyers
 func (s *BuyerServiceDefault) ReportPurchaseOrders() (po []internal.PurchaseOrdersByBuyer, err error) {
 	po, err = s.repo.ReportPurchaseOrders()
-	// Check if there is no buyers records
-	if len(po) == 0 {
-		return nil, ErrPurchaseOrdersNotFound
-	}
 	return
 }
 
@@ -115,9 +109,8 @@ func (s *BuyerServiceDefault) ReportPurchaseOrdersById(id int) (po []internal.Pu
 	}
 	// Get the purchase orders of the given buyer
 	po, err = s.repo.ReportPurchaseOrdersById(id)
-	// Check if there is no records for the given buyer
-	if len(po) == 0 {
-		return nil, ErrPurchaseOrdersByBuyerNotFound
+	if err != nil {
+		return nil, err
 	}
 	return
 }


### PR DESCRIPTION
# Fix ReportPurchaseOrders

## Descrição

O PR tem como intuito corrigir a implementação do ReportPurchaseOrders de Buyers. Antes, tinhamos os seguintes comportamentos ao fazer as requisições na nossa API:
### ❌ Antes 
-  **_/api/v1/buyers/report-purchase-orders_** para obter todos os Purchase Orders dos buyers:
   - Quando um buyer não tinha purchase_orders, ele não era incluído no resultado e só eram exibidos os buyers que tinham purchase orders.
- **_/api/v1/buyers/report-purchase-orders?id=2_** para obter a quantidade de purchase orders do buyer com o id passado (no caso do exemplo, 2):
   - Quando o buyer não tinha purchase_orders, era retornado um erro falando que não existe purchase orders para o buyer requisitado.

### ✅ Agora
-  **_/api/v1/buyers/report-purchase-orders_** para obter todos os Purchase Orders dos buyers:
   - Retorna todos os buyers com sua quantidade de purchase orders, inclusive os que não possuem purchase orders.
- **_/api/v1/buyers/report-purchase-orders?id=2_** para obter a quantidade de purchase orders do buyer com o id passado (no caso do exemplo, 2):
   - Retorna o buyer requisitado com a quantidade zero de purchase orders.

A mudança ocorreu pois em um relatório, de fato, toda informação é importante. O fato do buyer não ter nenhuma purchase order também é uma informação importante em um relatório, e não é nada consistente lançar um erro nesse caso. Ter acesso a essa informação, por exemplo, pode indicar um potencial problema de vendas, engajamento ou até uma oportunidade de marketing. Portanto, agora, todos os buyers são incluídos no relatório, com a quantidade de purchase orders refletindo com precisão a situação de cada um, o que contribui para um relatório mais fiel e útil para análises futuras.



## Tipo de Mudança

- [x] Correção de bug
- [ ] Nova funcionalidade
- [x] Melhoria de código
- [x] Refatoração
- [ ] Documentação

## Checklist

- [x] O código segue as convenções do projeto.
- [x] O código foi testado manualmente.
- [x] O código tem cobertura de testes automatizados.
- [ ] A documentação foi atualizada.
- [x] O PR não contém mudanças em arquivos não relacionados.
- [x] Os testes estão passando.
- [x] O código está livre de "TODOs" ou comentários de desenvolvimento.

